### PR TITLE
Fix several bugs in the startup logic and add an option to disable autocompletion by default.

### DIFF
--- a/doc/vimcomplete.txt
+++ b/doc/vimcomplete.txt
@@ -437,6 +437,12 @@ anytime using commands.
 	:VimCompleteEnable
 	:VimCompleteDisable
 
+To start Vm with autocompletion disabled, set the following variable.
+
+```
+g:vimcomplete_enable_by_default = true
+```
+
 You can selectively enable autocompletion for specified file types. For
 example, enable autocompletion for `c`, `cpp`, `python`, `vim`, `text`, and
 `markdown` files.
@@ -454,9 +460,10 @@ $HOME/.vimrc.
 autocmd VimEnter * VimCompleteEnable c cpp python vim text markdown
 ```
 
-When Vim is started without any arguments it opens an unnamed buffer. This
-buffer is not associated with any _file type_. To enable/disable
-autocompletion on this buffer use the following variable. It is set by default.
+When Vim is started without any arguments or a new buffer is created with
+:bufnew, it opens an unnamed buffer. This buffer is not associated with any
+_file type_. To enable/disable autocompletion on this buffer use the following
+variable. It is set by default.
 
 ```
 g:vimcomplete_noname_buf_enable = true

--- a/plugin/plugins.vim
+++ b/plugin/plugins.vim
@@ -14,13 +14,7 @@ import autoload '../autoload/omnifunc.vim'
 import autoload '../autoload/vimscript.vim'
 import autoload '../autoload/vsnip.vim'
 import autoload '../autoload/util.vim'
-
-# Enable completion in buffer loaded by default (which has no filetype)
 import '../autoload/completor.vim'
-g:vimcomplete_noname_buf_enable = true
-if get(g:, 'vimcomplete_noname_buf_enable', false)
-    completor.Enable()
-endif
 
 def RegisterPlugins()
     def Register(provider: string, ftypes: list<string>, priority: number)

--- a/plugin/vimcomplete.vim
+++ b/plugin/vimcomplete.vim
@@ -17,11 +17,33 @@ def VimCompEnable(filetypes: string)
     # will not have the filetype available to verify. One way to verify, if
     # necessary, is by using getcompletion().
     augroup VimcompleteAutoCmds | autocmd!
+		if get(g:, 'vimcomplete_noname_buf_enable', true)
+            autocmd BufNewFile * completor.Enable()
+
+			if &filetype == ""
+				# Special case for noname buffers.
+				completor.Enable()
+			endif
+		endif
+
         if ftypes->empty()
-            autocmd BufNewFile,BufReadPost * completor.Enable()
+            autocmd BufReadPost * completor.Enable()
             g:vimcomplete_noname_buf_enable = true
+
+			# Enable for the current buffer, but only if it's not a noname buffer.
+			if &filetype != ""
+				completor.Enable()
+			endif
         else
+			# New buffers with matching file type will start with
+			# completion enabled.
             exec $'autocmd FileType {ftypes->join(",")} completor.Enable()'
+
+			# Enable for the current buffer if it has a
+			# matching file type.
+			if index(ftypes, &filetype) >= 0
+				completor.Enable()
+			endif
         endif
     augroup END
 enddef
@@ -31,7 +53,9 @@ command! -nargs=0 VimCompleteDisable completor.Disable() | g:vimcomplete_noname_
 command! -nargs=0 VimCompleteCompletors completor.ShowCompletors()
 
 augroup VimcompleteAutoCmds | autocmd!
-    autocmd BufNewFile,BufReadPost,VimEnter * completor.Enable()
+	if get(g:, 'vimcomplete_enable_by_default', true)
+		autocmd VimEnter * VimCompEnable("")
+	endif
 augroup END
 
 if exists('#User#VimCompleteLoaded')


### PR DESCRIPTION
While reading through the code and trying to answer my questions submitted in #24, I came to the conclusion that the startup logic has at least two bugs / shortcommings:

* `g:vimcomplete_noname_buf_enable = false` doesn't work, it's always enabled.
* Autocompletion is always configued and enabled at startup.

This PR fixes these and some other shortcomings by refactoring the startup logic. It tries to stay backward compatible with the old behavior:

* Fix `g:vimcomplete_noname_buf_enable = false`
* Add a new option `g:vimcomplete:enable_by_default`. When set to `false` autocompletion isn't enabled at startup.
* `:VimCompleteEnable` now enables completion not only for new buffers, but also for the current buffer.

It is possible to make `:VimCompleteEnable` enable autocompletion for all loaded buffers, either unconditionally or based on filetype. Since messing with background buffer is fragile and prone to errors, I opted against it.