### PR TITLE
Fix abbrev completor on non-english installations

### DIFF
--- a/autoload/abbrev.vim
+++ b/autoload/abbrev.vim
@@ -9,7 +9,7 @@ export var options: dict<any> = {
 
 def GetAbbrevs(prefix: string): list<any>
     var lines = execute('ia', 'silent!')
-    if lines =~? 'No abbreviation found'
+    if lines =~? gettext('No abbreviation found')
         return []
     endif
     var abb = []


### PR DESCRIPTION
The abbrev completor breaks on non-english installations, because the error string is localized. Use `gettext()` to fetch the localized version if the error string and compare with it.