### PR TITLE
Fix bug and let buffer and dictionary haven't laggy

### DIFF
--- a/autoload/buffer.vim
+++ b/autoload/buffer.vim
@@ -20,7 +20,7 @@ export var options: dict<any> = {
 }
 
 # Return a list of keywords from a buffer
-def BufWords(bufnr: number, prefix: string, curbuf: bool = false): list<dict<any>>
+def BufWords(bufnr: number, prefix: string, curbuf: bool = false): list<any>
     var found = {}
     var start = reltime()
     var timeout = options.timeout
@@ -259,10 +259,14 @@ def CurBufMatches(prefix: string): list<dict<any>>
     return candidates
 enddef
 
+var empty_at_last_str = ''
 export def Completor(findstart: number, base: string): any
     if findstart == 2
         return 1
     elseif findstart == 1
+        if empty_at_last_str is base
+            return -2
+        endif
         var line = getline('.')->strpart(0, col('.') - 1)
         var prefix: string
         if options.urlComplete
@@ -274,9 +278,11 @@ export def Completor(findstart: number, base: string): any
         if prefix == ''
             prefix = line->matchstr('\k\+$')
             if prefix == ''
+                empty_at_last_str = base
                 return -2
             endif
         endif
+        empty_at_last_str = ''
         return line->len() - prefix->len() + 1
     endif
 

--- a/autoload/dictionary.vim
+++ b/autoload/dictionary.vim
@@ -211,15 +211,21 @@ enddef
 
 var completionItems: dict<any> = {}
 
+var empty_at_last_str = ''
 export def Completor(findstart: number, base: string): any
     if findstart == 2
         return 1
     elseif findstart == 1
+        if empty_at_last_str is base
+            return -2
+        endif
         var line = getline('.')->strpart(0, col('.') - 1)
         var prefix = OnlyWords() ? line->matchstr('\w\+$') : line->matchstr('\S\+$')
         if prefix == ''
+            empty_at_last_str = base
             return -2
         endif
+        empty_at_last_str = ''
         completionItems = GetCompletionItems(prefix)
         return completionItems.items->empty() ? -2 : completionItems.startcol
     endif


### PR DESCRIPTION
* fix bufWords fn bug ( return type ```list<dict<any>>``` to ```list<any>``` )
```zsh
Error detected while compiling VimEnter Autocommands for "*"..function VimComple
teOptionsSet[17]..<SNR>124_RegisterPlugins[11]..<lambda>30[4]..buffer#Completor[
38]..<SNR>126_BufWords:
line   35:
E1012: Type mismatch; expected list<dict<any>> but got list<string>
Error detected while compiling VimEnter Autocommands for "*"..function VimComple
teOptionsSet[17]..<SNR>124_RegisterPlugins[11]..<lambda>30[4]..buffer#Completor[
38]..<SNR>126_BufWords:
line   35:
E1028: Compiling :def function failed
```

* let buffer and Dictionary not  laggy
Add ```empty_at_last_str``` to determine