### PR TITLE
Honor `shellslash` option in path completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Both relative and absolute path names are completed.
 | `showPathSeparatorAtEnd`| `Boolean` | Show path separator (`/` in unix) at the end of directory entry. Default: `false`.    |
 
 > [!NOTE]
-> Path completion activates when there is a `/` (`\` for Windows) or `.` in the word before the cursor. To autocomplete deeper in a directory type `/` at the end.
+> Path completion activates when there is a `/` (`\` for Windows when Vim option `shellslash` is not set) or `.` in the word before the cursor. To autocomplete deeper in a directory type `/` at the end.
 
 ## Abbreviations Completion
 

--- a/autoload/vimcomplete/path.vim
+++ b/autoload/vimcomplete/path.vim
@@ -21,7 +21,7 @@ export def Completor(findstart: number, base: string): any
                 !(line->matchstr('\c\vhttp(s)?(:)?(/){0,2}\S+$')->empty())
             return -2
         endif
-        if prefix->empty() || prefix =~ '?$' || prefix !~ (has('unix') ? '/' : '\')
+        if prefix->empty() || prefix =~ '?$' || prefix !~ (has('unix') || &shellslash ? '/' : '\')
             return -2
         endif
         return col('.') - prefix->strlen()
@@ -29,7 +29,7 @@ export def Completor(findstart: number, base: string): any
 
     var citems = []
     var cwd: string = ''
-    var sep: string = has('win32') ? '\' : '/'
+    var sep: string = has('win32') && !&shellslash ? '\' : '/'
     try
         if options.bufferRelativePath && expand('%:h') !=# '.' # not already in buffer dir
             # change directory to get completions for paths relative to current buffer dir


### PR DESCRIPTION
This only affects Windows users; Vim's native path completion also honors `shellslash` option.

M  README.md
M  autoload/vimcomplete/path.vim