### PR TITLE
Support disabling or customizing `<CR>` maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,19 @@ vim9script
 g:vimcomplete_tab_enable = 1
 ```
 
+Additionally, `<Enter>` is mapped by default to insert the currently selected item and/or insert a literal `<CR>`, depending on configuration (see `noNewlineInCompletion` and `noNewlineInCompletionEver` options).
+
+In case of conflicts with other plugins, this mapping can be disabled entirely:
+
+```vim
+vim9script
+g:vimcomplete_cr_enable = 0
+```
+
+In this case, the user is responsible for defining an appropriate `<CR>` mapping to deconflict the plugins.
+In this mapping, consider emitting `<Plug>(vimcomplete-skip)` as necessary to prevent the next keystroke
+from automatically (re-)activating the completion popup. If `alwaysOn` is not used, this can be ignored.
+
 > [!NOTE]
 > For help with other keybindings see `:h popupmenu-keys`. This help section includes keybindings for `<BS>`, `CTRL-H`, `CTRL-L`, `CTRL-Y`, `CTRL-E`, `<PageUp>`, `<PageDown>`, `<Up>`, and `<Down>` keys when popup menu is open.
 

--- a/autoload/vimcomplete/completor.vim
+++ b/autoload/vimcomplete/completor.vim
@@ -257,7 +257,7 @@ enddef
 var skip_complete: bool = false
 
 export def SkipCompleteSet(): string
-    if pumvisible()
+    if options.alwaysOn && pumvisible()
         skip_complete = true
     endif
     return ''

--- a/autoload/vimcomplete/completor.vim
+++ b/autoload/vimcomplete/completor.vim
@@ -353,21 +353,7 @@ export def Enable()
     endif
     setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item')
 
-    if maparg('<cr>', 'i')->empty()
-        # if noNewlineInCompletion is false, <Enter> in insert mode accepts
-        # completion choice and inserts a newline
-        # if true, <cr> has default behavior (accept choice and insert newline,
-        # or dismiss popup without inserting newline).
-        # if noNewlineInCompletionEver is 'true' newline will not be inserted even if item is selected.
-        if options.noNewlineInCompletionEver
-            :inoremap <expr> <buffer> <cr> complete_info().selected > -1 ?
-                        \ "\<Plug>(vimcomplete-skip)\<c-y>" : "\<Plug>(vimcomplete-skip)\<cr>"
-        elseif options.noNewlineInCompletion
-            :inoremap <buffer> <cr> <Plug>(vimcomplete-skip)<cr>
-        else
-            :inoremap <expr> <buffer> <cr> pumvisible() ? "\<c-y>\<cr>" : "\<cr>"
-        endif
-    endif
+    util.CREnable()
 
     if options.alwaysOn
         :inoremap <buffer> <c-y> <Plug>(vimcomplete-skip)<c-y>

--- a/autoload/vimcomplete/util.vim
+++ b/autoload/vimcomplete/util.vim
@@ -31,6 +31,26 @@ export def TabEnable()
     :snoremap <buffer> <expr> <S-Tab> VCCleverSTab()
 enddef
 
+export def CREnable()
+    if !get(g:, 'vimcomplete_cr_enable', 1) || !maparg('<cr>', 'i')->empty()
+        return
+    endif
+    var copts = completor.options
+    # if noNewlineInCompletion is false, <Enter> in insert mode accepts
+    # completion choice and inserts a newline
+    # if true, <cr> has default behavior (accept choice and insert newline,
+    # or dismiss popup without inserting newline).
+    # if noNewlineInCompletionEver is 'true' newline will not be inserted even if item is selected.
+    if copts.noNewlineInCompletionEver
+        :inoremap <expr> <buffer> <cr> complete_info().selected > -1 ?
+                    \ "\<Plug>(vimcomplete-skip)\<c-y>" : "\<Plug>(vimcomplete-skip)\<cr>"
+    elseif copts.noNewlineInCompletion
+        :inoremap <buffer> <cr> <Plug>(vimcomplete-skip)<cr>
+    else
+        :inoremap <expr> <buffer> <cr> pumvisible() ? "\<c-y>\<cr>" : "\<cr>"
+    endif
+enddef
+
 # when completing word where cursor is in the middle, like xxx|yyy, yyy should
 # be hidden while tabbing through menu.
 var text_action_save = {

--- a/doc/vimcomplete.txt
+++ b/doc/vimcomplete.txt
@@ -481,7 +481,16 @@ default `<C-N>` and `<C-P>` select the menu items.
 >
 	g:vimcomplete_tab_enable = 1
 
-Highlight Groups ~
+Enter Handling~
+
+`<CR>` (`<Enter>`) key is rebound to insert the selected item and/or insert a
+literal `<CR>`, according to |vimcomplete-noNewlineInCompletion| and
+|vimcomplete-noNewlineInCompletionEver|. In case of conflicts with other
+plugins, this mapping can be entirely disabled:
+>
+	g:vimcomplete_cr_enable = 0
+
+Highlight Groups~
 
 You can use `Pmenu`, `PmenuThumb`, `PmenuSbar`, `PmenuSel`, `PmenuKind`,
 `PmenuKindSel`, `PmenuExtra` and `PmenuExtraSel` highlight groups to alter the


### PR DESCRIPTION
In case of conflicts with other plugins, the user might want to avoid using `<CR>` for completion, or to define their own `<CR>` mapping to deconflict the plugins. Accept `g:vimcomplete_cr_enable` (defaults to 1) to prevent the default `<CR>` mappings from being created, and document this possibility. Also briefly document the `<Plug>(vimcomplete-skip)` action that might be used when designing one's own `<CR>` mapping.

Additionally, ignore `<Plug>(vimcomplete-skip)` when `alwaysOn` is not used, as the TextChanged events that are supposed to "consume" the armed `skip_complete` switch will not fire, and it will instead affect the next explicit completion popup activation (i.e. the next `<C-Space>`).

Fixes #70.
