### PR TITLE
Suppress lsp error

### DIFF
--- a/autoload/vimcomplete/completor.vim
+++ b/autoload/vimcomplete/completor.vim
@@ -287,7 +287,7 @@ def VimComplete()
     endif
     if options.triggerWordLen > 0
         var keyword = line->matchstr('\k\+$')
-        if keyword->len() < options.triggerWordLen && lsp.GetTriggerKind() != 2
+        if keyword->len() < options.triggerWordLen && IsCompletor('lsp') && lsp.GetTriggerKind() != 2
             return
         endif
     endif


### PR DESCRIPTION
Suppresses the following error in filetypes that do not use lsp.
![image](https://github.com/user-attachments/assets/8242375c-02ed-40f9-a5db-0a3bb23f20e5)
