### PR TITLE
Document Vim version requirement for exemption from "triggerWordLen" limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Option|Type|Description
 `showSource`|`Boolean`|Show the source of the completion item in the menu. Default: `true`.
 `shuffleEqualPriority`|`Boolean`|Arrange items from sources with equal priority such that the first item of all sources appear before the second item of any source. Default: `false`.
 `sortByLength`|`Boolean`|Sort completion items by length. Default: `false`.
-`triggerWordLen`|`Number`|Minimum number of characters needed to trigger completion menu. Not applicable to completion triggered by LSP trigger characters. Default: `1`.
+`triggerWordLen`|`Number`|Minimum number of characters needed to trigger completion menu. Not applicable to completion triggered by LSP trigger characters (this exemption applies only to Vim version 9.1.650 or higher). Default: `1`.
 
 ## Buffer Completion
 


### PR DESCRIPTION
In README.md, the `triggerWordLen` option has the following description:
　`Not applicable to completion triggered by LSP trigger characters.`

But this feature is gated by [a check of Vim version 9.1.650+](https://github.com/girishji/vimcomplete/blob/dc92c2f9916095a88c6609bebdd64cd0a4b3e1a3/autoload/vimcomplete/lsp.vim#L71C20-L71C27), which is not mentioned in README.md.

This PR adds the version requirement to README.md.