### PR TITLE
Add new `infoPopup` completor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Option|Type|Description
 `shuffleEqualPriority`|`Boolean`|Arrange items from sources with equal priority such that the first item of all sources appear before the second item of any source. Default: `false`.
 `sortByLength`|`Boolean`|Sort completion items by length. Default: `false`.
 `triggerWordLen`|`Number`|Minimum number of characters needed to trigger completion menu. Not applicable to completion triggered by LSP trigger characters (this exemption applies only to Vim version 9.1.650 or higher). Default: `1`.
+`infoPopup`|`Boolean`|Show an info popup (`:h completepopup`) for extra information. Default: `true`.
 
 ## Buffer Completion
 

--- a/autoload/vimcomplete/completor.vim
+++ b/autoload/vimcomplete/completor.vim
@@ -346,10 +346,13 @@ enddef
 
 export def Enable()
     var bnr = bufnr()
-    # Hide the popup -- for customizing "info" popup window
-    setbufvar(bnr, '&completeopt', $'menuone,popuphidden,noselect,noinsert')
-
-    setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item')
+    if options.infoPopup
+        # Hide the popup -- for customizing "info" popup window
+        setbufvar(bnr, '&completeopt', $'menuone,popuphidden,noselect,noinsert')
+        setbufvar(bnr, '&completepopup', 'width:80,highlight:Pmenu,align:item')
+    else
+        setbufvar(bnr, '&completeopt', $'menuone,noselect,noinsert')
+    endif
 
     augroup VimCompBufAutocmds | autocmd! * <buffer>
         if options.alwaysOn
@@ -373,7 +376,9 @@ export def Enable()
             autocmd CompleteChanged <buffer> util.TextActionPre()
             autocmd CompleteDone,InsertLeave <buffer> util.UndoTextAction()
         endif
-        autocmd CompleteChanged <buffer> util.InfoPopupWindowSetOptions()
+        if options.infoPopup
+            autocmd CompleteChanged <buffer> util.InfoPopupWindowSetOptions()
+        endif
     augroup END
 
     if options.postfixHighlight

--- a/autoload/vimcomplete/options.vim
+++ b/autoload/vimcomplete/options.vim
@@ -20,6 +20,7 @@ export var options: dict<any> = {
     postfixClobber: false,  # remove yyy in xxx<cursor>yyy
     postfixHighlight: false, # highlight yyy in xxx<cursor>yyy
     triggerWordLen: 0,
+    infoPopup: true,
     throttleTimeout: 100,
     debug: false,
 }

--- a/doc/vimcomplete.txt
+++ b/doc/vimcomplete.txt
@@ -185,6 +185,11 @@ triggerWordLen		Number option. Minimum number of characters needed to
 			trigger completion menu. Not applicable to completion
 			triggered by LSP trigger characters. Default: `1`.
 
+						*vimcomplete-infopopup*
+infoPopup		Boolean option. Show an info popup for extra
+			information. This popup window can be customized with
+			|g:VimCompleteInfoWindowOptionsSet|. Default: `true`.
+
 Completion Provider General Options~
 
 Following options are common to all completion provider modules.
@@ -528,6 +533,7 @@ to the completion. By default, it is linked to `DiffChange`.
 
 Info Popup Window ~
 
+						*g:VimCompleteInfoWindowOptionsSet*
 Vim's completion system can display an additional popup window (referred to as
 the "info" window) next to the selected menu item when supplementary
 information is available.


### PR DESCRIPTION
Defaults to true. Show the "info" window/popup if true. Set to false to reduce window clutter / flicker, this can be beneficial for monitors that are small or with low refresh rate.

#93 